### PR TITLE
feat: add AI chat with Spline bubble and popover UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [0.29.0](https://github.com/henrynoowah/noowah.dev/compare/v0.28.0...v0.29.0) (2026-03-23)
+
+
+### Features
+
+* persist chat state across routes and fix mobile overflow ([0114261](https://github.com/henrynoowah/noowah.dev/commit/0114261c2983813d305553d5f2d0f8c055227ec8))
+
+
+
 # [0.28.0](https://github.com/henrynoowah/noowah.dev/compare/v0.27.0...v0.28.0) (2026-03-23)
 
 
@@ -42,15 +51,6 @@
 ### Bug Fixes
 
 * updated i18n handling ([464b4fd](https://github.com/henrynoowah/noowah.dev/commit/464b4fdf4cfc0ec12f910b2423c2c500d5387617))
-
-
-
-## [0.22.1](https://github.com/henrynoowah/noowah.dev/compare/v0.22.0...v0.22.1) (2024-05-10)
-
-
-### Bug Fixes
-
-* updated middleware matcher to prevent matching public directory ([c4ba54e](https://github.com/henrynoowah/noowah.dev/commit/c4ba54ec1d891f50a81efca103bcecbd35d70b46))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [0.28.0](https://github.com/henrynoowah/noowah.dev/compare/v0.27.0...v0.28.0) (2026-03-23)
+
+
+### Features
+
+* add shadcn popover chat on non-home pages and defer Spline render on route change ([838635b](https://github.com/henrynoowah/noowah.dev/commit/838635b58e5d0d70ffa1d633c74468614ea4af68))
+
+
+
 # [0.27.0](https://github.com/henrynoowah/noowah.dev/compare/v0.23.0...v0.27.0) (2026-03-23)
 
 
@@ -42,15 +51,6 @@
 ### Bug Fixes
 
 * updated middleware matcher to prevent matching public directory ([c4ba54e](https://github.com/henrynoowah/noowah.dev/commit/c4ba54ec1d891f50a81efca103bcecbd35d70b46))
-
-
-
-# [0.22.0](https://github.com/henrynoowah/noowah.dev/compare/v0.21.0...v0.22.0) (2024-05-09)
-
-
-### Features
-
-* added vercel.json ([f3627e4](https://github.com/henrynoowah/noowah.dev/commit/f3627e4c37fe4c6af1a5c29a01a2520761704736))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,56 @@
-# [0.26.0](https://github.com/henrynoowah/blog/compare/v0.23.0...v0.26.0) (2026-03-22)
+# [0.27.0](https://github.com/henrynoowah/noowah.dev/compare/v0.23.0...v0.27.0) (2026-03-23)
 
 
 ### Bug Fixes
 
-* use Locale type instead of LocalesValues in locale toggle ([9496642](https://github.com/henrynoowah/blog/commit/94966425ab0b5a0ec94ab43152ead8a0c4682364))
+* use Locale type instead of LocalesValues in locale toggle ([9496642](https://github.com/henrynoowah/noowah.dev/commit/94966425ab0b5a0ec94ab43152ead8a0c4682364))
 
 
 ### Features
 
-* add projects section to about page ([c612754](https://github.com/henrynoowah/blog/commit/c6127549a7bc8507ace3f7b0c18ac68b89e52204))
-* nextjs 16 update ([025c910](https://github.com/henrynoowah/blog/commit/025c91084f15468202c1cdcc447d3f3ff446f61b))
-* redesign about page hero with GSAP morph effect and consolidate works into about ([aa99926](https://github.com/henrynoowah/blog/commit/aa999268d59423de48d3c42e4663cb665b47479f))
-* redesign pages with editorial aesthetic, shadcn/ui, and Korean i18n ([5e17532](https://github.com/henrynoowah/blog/commit/5e17532841ae5b7c55696dfac6bab562ece07c2e))
-* view-transition-update ([5e0f744](https://github.com/henrynoowah/blog/commit/5e0f744bae42a3a36581e0f211ec01edcb54271d))
+* add persistent floating chat bubble with Spline morph transition ([e9cef56](https://github.com/henrynoowah/noowah.dev/commit/e9cef564fba5a4bde8563b9dd16c4214c40844fb))
+* add projects section to about page ([c612754](https://github.com/henrynoowah/noowah.dev/commit/c6127549a7bc8507ace3f7b0c18ac68b89e52204))
+* implement AI chat with OpenRouter streaming and markdown support ([c1d9e7a](https://github.com/henrynoowah/noowah.dev/commit/c1d9e7aaf9a5ede8d18342bd26fca30e9c5a5793))
+* nextjs 16 update ([025c910](https://github.com/henrynoowah/noowah.dev/commit/025c91084f15468202c1cdcc447d3f3ff446f61b))
+* redesign about page hero with GSAP morph and consolidate works ([#48](https://github.com/henrynoowah/noowah.dev/issues/48)) ([b8d37d9](https://github.com/henrynoowah/noowah.dev/commit/b8d37d91d89c34d2fd2308cab69ea07414e1a18c))
+* redesign pages with editorial aesthetic, shadcn/ui, and Korean i18n ([5e17532](https://github.com/henrynoowah/noowah.dev/commit/5e17532841ae5b7c55696dfac6bab562ece07c2e))
+* view-transition-update ([5e0f744](https://github.com/henrynoowah/noowah.dev/commit/5e0f744bae42a3a36581e0f211ec01edcb54271d))
 
 
 
-# [0.23.0](https://github.com/henrynoowah/blog/compare/v0.22.2...v0.23.0) (2024-10-22)
+# [0.23.0](https://github.com/henrynoowah/noowah.dev/compare/v0.22.2...v0.23.0) (2024-10-22)
 
 
 ### Features
 
-* next 15 version update ([209f3dc](https://github.com/henrynoowah/blog/commit/209f3dc921f0f621c69795048335d845666c30fa))
+* next 15 version update ([209f3dc](https://github.com/henrynoowah/noowah.dev/commit/209f3dc921f0f621c69795048335d845666c30fa))
 
 
 
-## [0.22.2](https://github.com/henrynoowah/blog/compare/v0.22.1...v0.22.2) (2024-06-13)
+## [0.22.2](https://github.com/henrynoowah/noowah.dev/compare/v0.22.1...v0.22.2) (2024-06-13)
 
 
 ### Bug Fixes
 
-* updated i18n handling ([464b4fd](https://github.com/henrynoowah/blog/commit/464b4fdf4cfc0ec12f910b2423c2c500d5387617))
+* updated i18n handling ([464b4fd](https://github.com/henrynoowah/noowah.dev/commit/464b4fdf4cfc0ec12f910b2423c2c500d5387617))
 
 
 
-## [0.22.1](https://github.com/henrynoowah/blog/compare/v0.22.0...v0.22.1) (2024-05-10)
+## [0.22.1](https://github.com/henrynoowah/noowah.dev/compare/v0.22.0...v0.22.1) (2024-05-10)
 
 
 ### Bug Fixes
 
-* updated middleware matcher to prevent matching public directory ([c4ba54e](https://github.com/henrynoowah/blog/commit/c4ba54ec1d891f50a81efca103bcecbd35d70b46))
+* updated middleware matcher to prevent matching public directory ([c4ba54e](https://github.com/henrynoowah/noowah.dev/commit/c4ba54ec1d891f50a81efca103bcecbd35d70b46))
 
 
 
-# [0.22.0](https://github.com/henrynoowah/blog/compare/v0.21.0...v0.22.0) (2024-05-09)
+# [0.22.0](https://github.com/henrynoowah/noowah.dev/compare/v0.21.0...v0.22.0) (2024-05-09)
 
 
 ### Features
 
-* added vercel.json ([f3627e4](https://github.com/henrynoowah/blog/commit/f3627e4c37fe4c6af1a5c29a01a2520761704736))
+* added vercel.json ([f3627e4](https://github.com/henrynoowah/noowah.dev/commit/f3627e4c37fe4c6af1a5c29a01a2520761704736))
 
 
 

--- a/app/[locale]/_components/chat-context.tsx
+++ b/app/[locale]/_components/chat-context.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+interface ChatContextValue {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+}
+
+const ChatContext = createContext<ChatContextValue>({
+  isOpen: false,
+  setIsOpen: () => {},
+});
+
+export const useChatContext = () => useContext(ChatContext);
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  return <ChatContext.Provider value={{ isOpen, setIsOpen }}>{children}</ChatContext.Provider>;
+}

--- a/app/[locale]/_components/chat-context.tsx
+++ b/app/[locale]/_components/chat-context.tsx
@@ -1,20 +1,56 @@
 'use client';
 
-import { createContext, useContext, useState, type ReactNode } from 'react';
+import { createContext, useContext, useRef, useState, type ReactNode } from 'react';
+
+export interface ChatMessage {
+  role: 'user' | 'model';
+  content: string;
+}
+
+const GREETING: ChatMessage = {
+  role: 'model',
+  content:
+    "Hi! I'm Hawoon's AI assistant. Ask me anything about his work, projects, or background.",
+};
 
 interface ChatContextValue {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
+  messages: ChatMessage[];
+  setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+  input: string;
+  setInput: (input: string) => void;
+  isLoading: boolean;
+  setIsLoading: (loading: boolean) => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
 }
 
 const ChatContext = createContext<ChatContextValue>({
   isOpen: false,
   setIsOpen: () => {},
+  messages: [GREETING],
+  setMessages: () => {},
+  input: '',
+  setInput: () => {},
+  isLoading: false,
+  setIsLoading: () => {},
+  inputRef: { current: null },
 });
 
 export const useChatContext = () => useContext(ChatContext);
 
 export function ChatProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
-  return <ChatContext.Provider value={{ isOpen, setIsOpen }}>{children}</ChatContext.Provider>;
+  const [messages, setMessages] = useState<ChatMessage[]>([GREETING]);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <ChatContext.Provider
+      value={{ isOpen, setIsOpen, messages, setMessages, input, setInput, isLoading, setIsLoading, inputRef }}
+    >
+      {children}
+    </ChatContext.Provider>
+  );
 }

--- a/app/[locale]/_components/floating-chat.tsx
+++ b/app/[locale]/_components/floating-chat.tsx
@@ -2,11 +2,15 @@
 
 import Spline from '@splinetool/react-spline';
 import { Application } from '@splinetool/runtime';
-import { cn } from '@/lib/utils';
 import { motion } from 'motion/react';
 import { usePathname } from 'next/navigation';
-import { useEffect, useRef } from 'react';
-import { ChatBox } from '@/components/common/chats';
+import { useEffect, useRef, useState } from 'react';
+import { ChatBox, ChatBoxContent } from '@/components/common/chats';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/components/ui/popover';
 import { useChatContext } from './chat-context';
 
 const scene = process.env.NEXT_PUBLIC_SPLINE_SCENE!;
@@ -23,6 +27,16 @@ export function FloatingChat({ locale }: { locale: string }) {
 
   const isHomeRef = useRef(isHome);
   isHomeRef.current = isHome;
+
+  // Defer Spline rendering until the layout animation finishes
+  const [layoutReady, setLayoutReady] = useState(true);
+  const prevIsHome = useRef(isHome);
+  useEffect(() => {
+    if (prevIsHome.current !== isHome) {
+      setLayoutReady(false);
+      prevIsHome.current = isHome;
+    }
+  }, [isHome]);
 
   // Track latest mouse position so we can re-dispatch after the container moves
   const mousePosRef = useRef({ x: 0, y: 0 });
@@ -44,12 +58,13 @@ export function FloatingChat({ locale }: { locale: string }) {
   }, [isHome]);
 
   const onAnimationComplete = () => {
+    setLayoutReady(true);
+
     // Re-dispatch mousemove so Spline recalculates cursor offset against new canvas position
     window.dispatchEvent(
       new MouseEvent('mousemove', {
         clientX: mousePosRef.current.x,
         clientY: mousePosRef.current.y,
-        bubbles: true,
       })
     );
 
@@ -91,6 +106,7 @@ export function FloatingChat({ locale }: { locale: string }) {
             height: '100%',
             borderRadius: 0,
             zIndex: 30,
+            backgroundColor: 'transparent',
           },
           bubble: {
             right: 24,
@@ -99,53 +115,66 @@ export function FloatingChat({ locale }: { locale: string }) {
             height: 64,
             borderRadius: 32,
             zIndex: 50,
+            backgroundColor: 'var(--accent)',
           },
         }}
         style={{
+          border: '1px solid var(--primary)',
           position: 'fixed',
           overflow: 'hidden',
           filter: 'grayscale(0.5) contrast(1.75)',
           pointerEvents: isHome ? 'none' : 'auto',
           cursor: isHome ? 'default' : 'pointer',
         }}
+        className="shadow-xl"
         transition={{ type: 'spring', stiffness: 150, damping: 25 }}
         onAnimationComplete={onAnimationComplete}
         onClick={!isHome ? () => setIsOpen(!isOpen) : undefined}
         whileHover={!isHome ? { scale: 1.1 } : undefined}
         whileTap={!isHome ? { scale: 0.95 } : undefined}
       >
-        {isHome ? (
-          <Spline scene={scene} onLoad={onLoad} />
-        ) : (
-          // Render at 400×400, scale down to fit 64px bubble
-          <div
-            style={{
-              position: 'absolute',
-              width: 400,
-              height: 400,
-              top: '50%',
-              left: '50%',
-              transformOrigin: 'center center',
-              transform: 'translate(-50%, -50%) scale(0.16)',
-              pointerEvents: 'none',
-            }}
-          >
+        {layoutReady &&
+          (isHome ? (
             <Spline scene={scene} onLoad={onLoad} />
-          </div>
-        )}
+          ) : (
+            // Render at 400×400, scale down to fit 64px bubble
+            <div
+              style={{
+                position: 'absolute',
+                width: 400,
+                height: 400,
+                top: '50%',
+                left: '50%',
+                transformOrigin: 'center center',
+                transform: 'translate(-50%, -50%) scale(0.14)',
+                pointerEvents: 'none',
+              }}
+            >
+              <Spline scene={scene} onLoad={onLoad} />
+            </div>
+          ))}
       </motion.div>
 
       {/* Chat box */}
       {isHome ? (
-        // Home: vertically centered, right-aligned — matches original layout
-        <div className="fixed inset-0 flex justify-end items-center pointer-events-none z-40 px-6 pb-16 md:pb-[100px]">
+        // Home: original centered overlay (no popover)
+        <div className="fixed inset-0 flex justify-center items-center pointer-events-none z-40 px-6 lg:translate-x-1/6">
           <ChatBox isOpen={isOpen} onClose={() => setIsOpen(false)} />
         </div>
       ) : (
-        // Other pages: above the bubble
-        <div className="fixed bottom-[104px] right-0 flex justify-end px-6 z-50 pointer-events-none w-full">
-          <ChatBox isOpen={isOpen} onClose={() => setIsOpen(false)} />
-        </div>
+        // Other pages: popover anchored to the bubble
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
+          <PopoverAnchor className="fixed bottom-6 right-6 w-16 h-16" />
+          <PopoverContent
+            side="top"
+            align="end"
+            sideOffset={16}
+            className="w-[400px] h-[480px] max-h-[70vh] p-0 bg-primary/20 backdrop-blur-lg rounded-[24px] shadow-xl overflow-hidden"
+            onOpenAutoFocus={e => e.preventDefault()}
+          >
+            <ChatBoxContent onClose={() => setIsOpen(false)} />
+          </PopoverContent>
+        </Popover>
       )}
     </>
   );

--- a/app/[locale]/_components/floating-chat.tsx
+++ b/app/[locale]/_components/floating-chat.tsx
@@ -169,7 +169,7 @@ export function FloatingChat({ locale }: { locale: string }) {
             side="top"
             align="end"
             sideOffset={16}
-            className="w-[400px] h-[480px] max-h-[70vh] p-0 bg-primary/20 backdrop-blur-lg rounded-[24px] shadow-xl overflow-hidden"
+            className="w-[calc(100vw-3rem)] sm:w-[400px] h-[60vh] sm:h-[480px] max-h-[70vh] p-0 bg-primary/20 backdrop-blur-lg rounded-[24px] shadow-xl overflow-hidden"
             onOpenAutoFocus={e => e.preventDefault()}
           >
             <ChatBoxContent onClose={() => setIsOpen(false)} />

--- a/app/[locale]/_components/floating-chat.tsx
+++ b/app/[locale]/_components/floating-chat.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import Spline from '@splinetool/react-spline';
+import { Application } from '@splinetool/runtime';
+import { cn } from '@/lib/utils';
+import { motion } from 'motion/react';
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { ChatBox } from '@/components/common/chats';
+import { useChatContext } from './chat-context';
+
+const scene = process.env.NEXT_PUBLIC_SPLINE_SCENE!;
+const splitBotId = process.env.NEXT_PUBLIC_SPLINE_BOT_ID;
+
+export function FloatingChat({ locale }: { locale: string }) {
+  const pathname = usePathname();
+  const { isOpen, setIsOpen } = useChatContext();
+  const splineRef = useRef<Application>(null);
+
+  // Default locale (en) has no prefix → path is '/', other locales use '/ko' etc.
+  const isHome =
+    pathname === '/' || pathname === `/${locale}` || pathname === `/${locale}/`;
+
+  const isHomeRef = useRef(isHome);
+  isHomeRef.current = isHome;
+
+  // Track latest mouse position so we can re-dispatch after the container moves
+  const mousePosRef = useRef({ x: 0, y: 0 });
+  useEffect(() => {
+    const track = (e: MouseEvent) => {
+      mousePosRef.current = { x: e.clientX, y: e.clientY };
+    };
+    window.addEventListener('mousemove', track);
+    return () => window.removeEventListener('mousemove', track);
+  }, []);
+
+  const onLoad = (spline: Application) => {
+    splineRef.current = spline;
+  };
+
+  // Close chat immediately when leaving home (don't wait for transition)
+  useEffect(() => {
+    if (!isHome) setIsOpen(false);
+  }, [isHome]);
+
+  const onAnimationComplete = () => {
+    // Re-dispatch mousemove so Spline recalculates cursor offset against new canvas position
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        clientX: mousePosRef.current.x,
+        clientY: mousePosRef.current.y,
+        bubbles: true,
+      })
+    );
+
+    if (!splineRef.current || !splitBotId) return;
+    if (isHome) {
+      if (isHomeRef.current) {
+        const bot = splineRef.current.findObjectByName(splitBotId);
+        bot?.emitEvent('mouseDown');
+      } else {
+        splineRef.current.emitEventReverse('mouseDown', splitBotId);
+      }
+    }
+  };
+
+  // Sync Spline bot animation with chat open state (home only)
+  useEffect(() => {
+    if (!splineRef.current || !splitBotId || !isHome) return;
+    if (isHome) {
+      if (isOpen) {
+        splineRef.current.emitEvent('mouseDown', splitBotId);
+      } else {
+        splineRef.current.emitEventReverse('mouseDown', splitBotId);
+      }
+    }
+  }, [isOpen, isHome]);
+
+  return (
+    <>
+      {/* Spline scene — morphs between full-screen (home) and bubble (other pages) */}
+      <motion.div
+        initial={false}
+        animate={isHome ? 'home' : 'bubble'}
+        variants={{
+          // Anchor from bottom-right so no top/left conflicts during animation
+          home: {
+            right: 0,
+            bottom: 0,
+            width: '100%',
+            height: '100%',
+            borderRadius: 0,
+            zIndex: 30,
+          },
+          bubble: {
+            right: 24,
+            bottom: 24,
+            width: 64,
+            height: 64,
+            borderRadius: 32,
+            zIndex: 50,
+          },
+        }}
+        style={{
+          position: 'fixed',
+          overflow: 'hidden',
+          filter: 'grayscale(0.5) contrast(1.75)',
+          pointerEvents: isHome ? 'none' : 'auto',
+          cursor: isHome ? 'default' : 'pointer',
+        }}
+        transition={{ type: 'spring', stiffness: 150, damping: 25 }}
+        onAnimationComplete={onAnimationComplete}
+        onClick={!isHome ? () => setIsOpen(!isOpen) : undefined}
+        whileHover={!isHome ? { scale: 1.1 } : undefined}
+        whileTap={!isHome ? { scale: 0.95 } : undefined}
+      >
+        {isHome ? (
+          <Spline scene={scene} onLoad={onLoad} />
+        ) : (
+          // Render at 400×400, scale down to fit 64px bubble
+          <div
+            style={{
+              position: 'absolute',
+              width: 400,
+              height: 400,
+              top: '50%',
+              left: '50%',
+              transformOrigin: 'center center',
+              transform: 'translate(-50%, -50%) scale(0.16)',
+              pointerEvents: 'none',
+            }}
+          >
+            <Spline scene={scene} onLoad={onLoad} />
+          </div>
+        )}
+      </motion.div>
+
+      {/* Chat box */}
+      {isHome ? (
+        // Home: vertically centered, right-aligned — matches original layout
+        <div className="fixed inset-0 flex justify-end items-center pointer-events-none z-40 px-6 pb-16 md:pb-[100px]">
+          <ChatBox isOpen={isOpen} onClose={() => setIsOpen(false)} />
+        </div>
+      ) : (
+        // Other pages: above the bubble
+        <div className="fixed bottom-[104px] right-0 flex justify-end px-6 z-50 pointer-events-none w-full">
+          <ChatBox isOpen={isOpen} onClose={() => setIsOpen(false)} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/[locale]/_components/main-container.tsx
+++ b/app/[locale]/_components/main-container.tsx
@@ -86,7 +86,7 @@ const MainContainer = () => {
       <div
         className={`absolute pointer-events-none w-full h-full max-w-[1020px] px-[24px] pt-4 pb-[40px] md:pb-[100px] flex justify-end items-center z-30`}
       >
-        <ChatBox isOpen={isBotChatOpened} />
+        <ChatBox isOpen={isBotChatOpened} onClose={() => setIsBotChatOpened(false)} />
       </div>
 
       <div className="absolute bottom-4 right-4 md:right-1/2 transform md:translate-x-1/2 z-50">

--- a/app/[locale]/_components/main-container.tsx
+++ b/app/[locale]/_components/main-container.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ChatBox } from '@/components/common/chats';
 import { Dock, DockIcon } from '@/components/ui/dock';
 import { FlickeringGrid } from '@/components/ui/flickering-grid';
 import { Separator } from '@/components/ui/separator';
@@ -9,8 +8,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import Spline from '@splinetool/react-spline';
-import { Application, SPEObject } from '@splinetool/runtime';
 import {
   IconBlockquote,
   IconBrandGithub,
@@ -21,35 +18,14 @@ import {
 import { useIntlayer, useLocale } from 'next-intlayer';
 import { getLocalizedUrl } from 'intlayer';
 import Link from 'next/link';
-import { useRef, useState } from 'react';
 import { LocaleToggle } from './locale-toggle';
 import { AnimatedThemeToggler } from '@/components/ui/animated-theme-toggler';
-
-const scene = process.env.NEXT_PUBLIC_SPLINE_SCENE!;
-const splitBotId = process.env.NEXT_PUBLIC_SPLINE_BOT_ID!;
+import { useChatContext } from './chat-context';
 
 const MainContainer = () => {
   const { ...content } = useIntlayer('home-page');
   const { locale } = useLocale();
-
-  const toggleChat = () => {
-    !!isBotChatOpened
-      ? splineRef.current?.emitEventReverse('mouseDown', splitBotId)
-      : splineRef.current?.emitEvent('mouseDown', splitBotId);
-    setIsBotChatOpened(!isBotChatOpened);
-  };
-
-  const [isBotChatOpened, setIsBotChatOpened] = useState<boolean>(false);
-
-  const botRef = useRef<SPEObject>(null);
-  const splineRef = useRef<Application>(null);
-
-  const onLoad = (spline: Application) => {
-    splineRef.current = spline;
-    const botObj = spline.findObjectByName(splitBotId);
-    botObj?.emitEvent('mouseDown');
-    if (botObj) botRef.current = botObj;
-  };
+  const { isOpen, setIsOpen } = useChatContext();
 
   return (
     <div className="pointer-events-auto h-dvh">
@@ -65,14 +41,6 @@ const MainContainer = () => {
       </div>
 
       <div
-        className="absolute w-full h-full
-            flex justify-center items-center z-30 pointer-events-none"
-        style={{ filter: 'grayscale(0.5) contrast(1.75)' }}
-      >
-        <Spline scene={scene} onLoad={onLoad} />
-      </div>
-
-      <div
         className={`fixed flex gap-2 justify-end z-30 pointer-events-auto top-4 end-4`}
       >
         <div className="rounded-full bg-primary text-primary-foreground flex items-center justify-center p-2">
@@ -81,12 +49,6 @@ const MainContainer = () => {
         <div className="rounded-full bg-primary text-primary-foreground flex items-center justify-center p-2">
           <LocaleToggle />
         </div>
-      </div>
-
-      <div
-        className={`absolute pointer-events-none w-full h-full max-w-[1020px] px-[24px] pt-4 pb-[40px] md:pb-[100px] flex justify-end items-center z-30`}
-      >
-        <ChatBox isOpen={isBotChatOpened} onClose={() => setIsBotChatOpened(false)} />
       </div>
 
       <div className="absolute bottom-4 right-4 md:right-1/2 transform md:translate-x-1/2 z-50">
@@ -157,7 +119,7 @@ const MainContainer = () => {
                 onClick={e => {
                   e.stopPropagation();
                   e.preventDefault();
-                  toggleChat();
+                  setIsOpen(!isOpen);
                 }}
               >
                 <IconMessageCircle className="size-full" />{' '}

--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -79,9 +79,21 @@ const AboutPage: NextPageIntlayer = ({ params }) => {
   const introY = useTransform(scrollYProgress, [0, 1], [60, -60]);
 
   const stats = [
-    { key: 'experience', value: content.introduction.stats.experience.value, label: content.introduction.stats.experience.label },
-    { key: 'leadership', value: content.introduction.stats.leadership.value, label: content.introduction.stats.leadership.label },
-    { key: 'industry', value: content.introduction.stats.industry.value, label: content.introduction.stats.industry.label },
+    {
+      key: 'experience',
+      value: content.introduction.stats.experience.value,
+      label: content.introduction.stats.experience.label,
+    },
+    {
+      key: 'leadership',
+      value: content.introduction.stats.leadership.value,
+      label: content.introduction.stats.leadership.label,
+    },
+    {
+      key: 'industry',
+      value: content.introduction.stats.industry.value,
+      label: content.introduction.stats.industry.label,
+    },
   ];
 
   const skillCategories = Object.entries(content.skills.categories) as Array<
@@ -139,7 +151,7 @@ const AboutPage: NextPageIntlayer = ({ params }) => {
   ];
 
   return (
-    <div className="w-full">
+    <div className="w-full overflow-x-hidden">
       {/* ─── Hero ─── */}
       <HeroHighlight>
         <div className="max-w-5xl mx-auto px-6 w-full">
@@ -161,13 +173,17 @@ const AboutPage: NextPageIntlayer = ({ params }) => {
             <TextScramble
               text="NOOWAH"
               revealText="HAWOON"
-              className="font-serif text-5xl md:text-7xl lg:text-8xl font-extrabold text-foreground leading-[0.9] tracking-tight md:text-center uppercase"
+              className="font-serif text-[10vw] md:text-7xl lg:text-8xl font-extrabold text-foreground leading-[0.9] tracking-tight md:text-center uppercase"
             />
 
             <motion.div
               initial={{ scaleX: 0 }}
               animate={{ scaleX: 1 }}
-              transition={{ delay: 0.7, duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
+              transition={{
+                delay: 0.7,
+                duration: 0.8,
+                ease: [0.22, 1, 0.36, 1],
+              }}
               className="w-24 h-px bg-primary/40 mt-8 origin-left"
             />
           </motion.div>
@@ -175,7 +191,10 @@ const AboutPage: NextPageIntlayer = ({ params }) => {
       </HeroHighlight>
 
       {/* ─── Introduction ─── */}
-      <div ref={introRef} className="relative max-w-5xl mx-auto px-6 py-24 md:py-32">
+      <div
+        ref={introRef}
+        className="relative max-w-5xl mx-auto px-6 py-24 md:py-32"
+      >
         <SectionLabel>{content.sections.about}</SectionLabel>
 
         <div className="grid md:grid-cols-12 gap-8 md:gap-12 items-start">
@@ -234,7 +253,11 @@ const AboutPage: NextPageIntlayer = ({ params }) => {
                 initial={{ opacity: 0, y: 24 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
-                transition={{ duration: 0.5, delay: index * 0.08, ease: [0.22, 1, 0.36, 1] }}
+                transition={{
+                  duration: 0.5,
+                  delay: index * 0.08,
+                  ease: [0.22, 1, 0.36, 1],
+                }}
                 className={span}
               >
                 <Card className="h-full border-border/40 bg-card/50 backdrop-blur-sm hover:bg-card transition-all duration-500 group overflow-hidden relative">
@@ -251,22 +274,26 @@ const AboutPage: NextPageIntlayer = ({ params }) => {
                   </CardHeader>
                   <CardContent className="relative">
                     <div className="flex flex-wrap gap-2">
-                      {(category.skills as string[]).map((skill, skillIndex) => (
-                        <motion.div
-                          key={`${key}-skill-${skillIndex}`}
-                          initial={{ opacity: 0, scale: 0.9 }}
-                          whileInView={{ opacity: 1, scale: 1 }}
-                          viewport={{ once: true }}
-                          transition={{ delay: index * 0.08 + skillIndex * 0.05 }}
-                        >
-                          <Badge
-                            variant="outline"
-                            className="text-xs font-light border-border/60 text-muted-foreground hover:text-foreground hover:border-primary/40 transition-all duration-300"
+                      {(category.skills as string[]).map(
+                        (skill, skillIndex) => (
+                          <motion.div
+                            key={`${key}-skill-${skillIndex}`}
+                            initial={{ opacity: 0, scale: 0.9 }}
+                            whileInView={{ opacity: 1, scale: 1 }}
+                            viewport={{ once: true }}
+                            transition={{
+                              delay: index * 0.08 + skillIndex * 0.05,
+                            }}
                           >
-                            {skill}
-                          </Badge>
-                        </motion.div>
-                      ))}
+                            <Badge
+                              variant="outline"
+                              className="text-xs font-light border-border/60 text-muted-foreground hover:text-foreground hover:border-primary/40 transition-all duration-300"
+                            >
+                              {skill}
+                            </Badge>
+                          </motion.div>
+                        )
+                      )}
                     </div>
                   </CardContent>
                 </Card>
@@ -391,10 +418,12 @@ const AboutPage: NextPageIntlayer = ({ params }) => {
           <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6 md:gap-8">
             <div className="min-w-0">
               <SectionLabel>{content.sections.contact}</SectionLabel>
-              <h2 className="font-serif text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-extrabold text-foreground leading-[0.9] uppercase break-words">
+              <h2 className="font-serif text-2xl sm:text-4xl md:text-6xl lg:text-7xl font-extrabold text-foreground leading-[0.9] uppercase break-words">
                 {content.contact.titleLine1}
                 <br />
-                <span className="text-primary">{content.contact.titleHighlight}</span>{' '}
+                <span className="text-primary">
+                  {content.contact.titleHighlight}
+                </span>{' '}
                 {content.contact.titleLine2}
               </h2>
             </div>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -3,6 +3,8 @@ import { getHTMLTextDir } from 'intlayer';
 import { Metadata } from 'next';
 import type { NextLayoutIntlayer } from 'next-intlayer';
 import { Syne, Outfit, Noto_Sans_KR } from 'next/font/google';
+import { ChatProvider } from './_components/chat-context';
+import { FloatingChat } from './_components/floating-chat';
 
 const syne = Syne({
   subsets: ['latin'],
@@ -87,7 +89,12 @@ const LocaleLayout: NextLayoutIntlayer = async ({ children, params }) => {
         <link rel="manifest" href="/site.webmanifest" />
       </head>
       <body suppressHydrationWarning={true}>
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <ChatProvider>
+            <FloatingChat locale={locale} />
+            {children}
+          </ChatProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const SYSTEM_PROMPT = `You are an AI assistant on Hawoon Joh's personal blog. Henry goes by the handle "NOOWAH" online.
+
+## Identity
+- Name: Hawoon Joh (조하운)
+- Role: Frontend Developer & Team Lead
+- Location: Seoul, Korea
+- Email: henrynoowah@gmail.com
+- GitHub: github.com/henrynoowah
+- Blog: velog.io/@henrynoowah
+
+## Background
+Henry has 3+ years of experience specializing in Next.js and TypeScript. He holds a Bachelor's degree in Spatial Design from Kookmin University (Korea, 2020), which gives him a design-informed perspective — focusing on layout, spatial relationships, and user experience when building web applications.
+
+## Work
+- **2022 – Present**: Frontend Developer & Team Lead at CloudHospital
+  - Leads frontend development initiatives and manages the development team
+  - Specializes in Next.js, TypeScript, and modern frontend architecture for healthcare applications
+
+## Skills
+- **Frontend**: Next.js, TypeScript, React, Tailwind CSS
+- **Tools & DevOps**: Git, VS Code, Vercel, GitHub Actions, CI/CD
+- **Industry**: Healthcare Tech, Frontend Architecture, Team Management
+
+## Projects
+1. **shadcn/ui RJSF Form Builder** — A form builder powered by react-jsonschema-form with shadcn/ui components. Generates dynamic forms from JSON Schema with a visual builder interface. (React, JSON Schema, shadcn/ui)
+2. **CMS Content Builder** — A visual UI editor and content builder with a component-driven architecture. Drag-and-drop interface for building rich content layouts. (UI Editor, CMS, Storybook, Component Library)
+3. **node-pr-versioning** — A GitHub Action that automates Node.js package versioning via PR labels. Supports major/minor/patch bumps, monorepo paths, custom commit messages, tag generation, and dry-run mode. (GitHub Action, Node.js, CI/CD)
+
+## Your role
+- Help visitors learn about Henry's work, projects, and background
+- Answer questions about his tech stack, career, or projects
+- Be friendly, concise, and helpful
+- If asked about something not covered above, say so honestly rather than guessing
+- Respond in the same language the user writes in (English or Korean)
+- Use markdown formatting where appropriate (lists, bold, code blocks, etc.)`;
+
+interface ChatMessage {
+  role: 'user' | 'model';
+  content: string;
+}
+
+export async function POST(req: NextRequest) {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'OPENROUTER_API_KEY not configured' }, { status: 500 });
+  }
+
+  const { messages }: { messages: ChatMessage[] } = await req.json();
+  if (!messages?.length) {
+    return NextResponse.json({ error: 'No messages provided' }, { status: 400 });
+  }
+
+  const openaiMessages = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    ...messages.map((m) => ({
+      role: m.role === 'model' ? 'assistant' : 'user',
+      content: m.content,
+    })),
+  ];
+
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'stepfun/step-3.5-flash:free',
+      messages: openaiMessages,
+      stream: true,
+    }),
+  });
+
+  if (!res.ok || !res.body) {
+    const err = await res.json().catch(() => ({}));
+    console.error('[/api/chat] OpenRouter error:', err);
+    const status = res.status === 429 ? 429 : 500;
+    const userMessage =
+      status === 429
+        ? 'Rate limit reached. Please wait a moment and try again.'
+        : 'Something went wrong. Please try again.';
+    return NextResponse.json({ error: userMessage }, { status });
+  }
+
+  // Forward the SSE stream, extracting just the text deltas
+  const stream = new ReadableStream({
+    async start(controller) {
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const data = line.slice(6).trim();
+            if (data === '[DONE]') return;
+            try {
+              const json = JSON.parse(data);
+              const delta = json.choices?.[0]?.delta?.content;
+              if (delta) controller.enqueue(new TextEncoder().encode(delta));
+            } catch {
+              // skip malformed chunks
+            }
+          }
+        }
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/components/common/chats/index.tsx
+++ b/components/common/chats/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { cn } from '@/lib/utils';
 import { motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { IconSend, IconX } from '@tabler/icons-react';
@@ -25,7 +26,8 @@ interface Params {
 
 const GREETING: ChatMessage = {
   role: 'model',
-  content: "Hi! I'm Hawoon's AI assistant. Ask me anything about his work, projects, or background.",
+  content:
+    "Hi! I'm Hawoon's AI assistant. Ask me anything about his work, projects, or background.",
 };
 
 const MarkdownContent = ({ content }: { content: string }) => (
@@ -33,10 +35,16 @@ const MarkdownContent = ({ content }: { content: string }) => (
     remarkPlugins={[remarkGfm]}
     components={{
       p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
-      ul: ({ children }) => <ul className="list-disc pl-4 mb-1 space-y-0.5">{children}</ul>,
-      ol: ({ children }) => <ol className="list-decimal pl-4 mb-1 space-y-0.5">{children}</ol>,
+      ul: ({ children }) => (
+        <ul className="list-disc pl-4 mb-1 space-y-0.5">{children}</ul>
+      ),
+      ol: ({ children }) => (
+        <ol className="list-decimal pl-4 mb-1 space-y-0.5">{children}</ol>
+      ),
       li: ({ children }) => <li className="leading-snug">{children}</li>,
-      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+      strong: ({ children }) => (
+        <strong className="font-semibold">{children}</strong>
+      ),
       code: ({ children, className }) => {
         const isBlock = className?.includes('language-');
         return isBlock ? (
@@ -44,11 +52,18 @@ const MarkdownContent = ({ content }: { content: string }) => (
             <code>{children}</code>
           </pre>
         ) : (
-          <code className="bg-black/20 rounded px-1 py-0.5 text-xs font-mono">{children}</code>
+          <code className="bg-black/20 rounded px-1 py-0.5 text-xs font-mono">
+            {children}
+          </code>
         );
       },
       a: ({ href, children }) => (
-        <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:opacity-80">
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:opacity-80"
+        >
           {children}
         </a>
       ),
@@ -79,7 +94,7 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
     setIsLoading(true);
 
     // Add empty assistant message to stream into
-    setMessages((prev) => [...prev, { role: 'model', content: '' }]);
+    setMessages(prev => [...prev, { role: 'model', content: '' }]);
 
     try {
       const res = await fetch('/api/chat', {
@@ -89,7 +104,9 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
       });
 
       if (!res.ok) {
-        const { error } = await res.json().catch(() => ({ error: 'Something went wrong.' }));
+        const { error } = await res
+          .json()
+          .catch(() => ({ error: 'Something went wrong.' }));
         throw new Error(error);
       }
 
@@ -100,7 +117,7 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
         const { done, value } = await reader.read();
         if (done) break;
         const chunk = decoder.decode(value, { stream: true });
-        setMessages((prev) => {
+        setMessages(prev => {
           const updated = [...prev];
           updated[updated.length - 1] = {
             role: 'model',
@@ -110,8 +127,9 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
         });
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Sorry, something went wrong.';
-      setMessages((prev) => {
+      const msg =
+        err instanceof Error ? err.message : 'Sorry, something went wrong.';
+      setMessages(prev => {
         const updated = [...prev];
         updated[updated.length - 1] = { role: 'model', content: msg };
         return updated;
@@ -123,7 +141,10 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
 
   return (
     <motion.div
-      className="w-[400px] max-w-full h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] shadow-xl backdrop-filter backdrop-blur-lg flex flex-col overflow-hidden pointer-events-auto"
+      className={cn(
+        'w-[400px] max-w-full h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] shadow-xl backdrop-filter backdrop-blur-lg flex flex-col overflow-hidden',
+        isOpen ? 'pointer-events-auto' : 'pointer-events-none'
+      )}
       initial={{ opacity: 0 }}
       animate={!!isOpen ? 'open' : 'closed'}
       variants={{
@@ -180,8 +201,8 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
         <input
           ref={inputRef}
           value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && sendMessage()}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && !e.shiftKey && sendMessage()}
           placeholder="Ask me anything..."
           disabled={isLoading}
           className="flex-1 bg-primary/20 rounded-full px-4 py-2 text-sm outline-none placeholder:text-foreground/40 disabled:opacity-50"

--- a/components/common/chats/index.tsx
+++ b/components/common/chats/index.tsx
@@ -1,14 +1,129 @@
+'use client';
+
 import { motion } from 'motion/react';
+import { useEffect, useRef, useState } from 'react';
+import { IconSend, IconX } from '@tabler/icons-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from '@/components/ui/conversation';
+import { Message, MessageContent } from '@/components/ui/message';
+import { ShimmeringText } from '@/components/ui/shimmering-text';
+
+interface ChatMessage {
+  role: 'user' | 'model';
+  content: string;
+}
 
 interface Params {
   isOpen: boolean;
-  onClose?: (close: boolean) => void;
+  onClose?: () => void;
 }
 
-const ChatBox = ({ isOpen }: Params) => {
+const GREETING: ChatMessage = {
+  role: 'model',
+  content: "Hi! I'm Hawoon's AI assistant. Ask me anything about his work, projects, or background.",
+};
+
+const MarkdownContent = ({ content }: { content: string }) => (
+  <ReactMarkdown
+    remarkPlugins={[remarkGfm]}
+    components={{
+      p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
+      ul: ({ children }) => <ul className="list-disc pl-4 mb-1 space-y-0.5">{children}</ul>,
+      ol: ({ children }) => <ol className="list-decimal pl-4 mb-1 space-y-0.5">{children}</ol>,
+      li: ({ children }) => <li className="leading-snug">{children}</li>,
+      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+      code: ({ children, className }) => {
+        const isBlock = className?.includes('language-');
+        return isBlock ? (
+          <pre className="bg-black/20 rounded px-2 py-1.5 text-xs overflow-x-auto my-1">
+            <code>{children}</code>
+          </pre>
+        ) : (
+          <code className="bg-black/20 rounded px-1 py-0.5 text-xs font-mono">{children}</code>
+        );
+      },
+      a: ({ href, children }) => (
+        <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:opacity-80">
+          {children}
+        </a>
+      ),
+    }}
+  >
+    {content}
+  </ReactMarkdown>
+);
+
+const ChatBox = ({ isOpen, onClose }: Params) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([GREETING]);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) setTimeout(() => inputRef.current?.focus(), 600);
+  }, [isOpen]);
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+
+    const userMessage: ChatMessage = { role: 'user', content: text };
+    const nextMessages = [...messages, userMessage];
+    setMessages(nextMessages);
+    setInput('');
+    setIsLoading(true);
+
+    // Add empty assistant message to stream into
+    setMessages((prev) => [...prev, { role: 'model', content: '' }]);
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: nextMessages }),
+      });
+
+      if (!res.ok) {
+        const { error } = await res.json().catch(() => ({ error: 'Something went wrong.' }));
+        throw new Error(error);
+      }
+
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        setMessages((prev) => {
+          const updated = [...prev];
+          updated[updated.length - 1] = {
+            role: 'model',
+            content: updated[updated.length - 1].content + chunk,
+          };
+          return updated;
+        });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Sorry, something went wrong.';
+      setMessages((prev) => {
+        const updated = [...prev];
+        updated[updated.length - 1] = { role: 'model', content: msg };
+        return updated;
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <motion.div
-      className={`w-[400px] max-w-full h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] p-4 shadow-xl backdrop-filter backdrop-blur-lg`}
+      className="w-[400px] max-w-full h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] shadow-xl backdrop-filter backdrop-blur-lg flex flex-col overflow-hidden pointer-events-auto"
       initial={{ opacity: 0 }}
       animate={!!isOpen ? 'open' : 'closed'}
       variants={{
@@ -24,8 +139,60 @@ const ChatBox = ({ isOpen }: Params) => {
         }),
       }}
     >
-      <div className="w-full h-full flex justify-center items-center font-semibold">
-        Coming Soon...!
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-primary/20">
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+          <span className="text-sm font-semibold">AI Assistant</span>
+        </div>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="p-1 rounded-full hover:bg-primary/20 transition-colors"
+          >
+            <IconX className="size-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Messages */}
+      <Conversation className="flex-1">
+        <ConversationContent className="space-y-1">
+          {messages.map((msg, i) => (
+            <Message key={i} from={msg.role === 'user' ? 'user' : 'assistant'}>
+              <MessageContent>
+                {msg.role === 'model' && !msg.content && isLoading ? (
+                  <ShimmeringText text="Thinking..." duration={1.5} />
+                ) : msg.role === 'model' ? (
+                  <MarkdownContent content={msg.content} />
+                ) : (
+                  msg.content
+                )}
+              </MessageContent>
+            </Message>
+          ))}
+        </ConversationContent>
+        <ConversationScrollButton className="bottom-2" />
+      </Conversation>
+
+      {/* Input */}
+      <div className="px-4 py-3 border-t border-primary/20 flex gap-2">
+        <input
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && sendMessage()}
+          placeholder="Ask me anything..."
+          disabled={isLoading}
+          className="flex-1 bg-primary/20 rounded-full px-4 py-2 text-sm outline-none placeholder:text-foreground/40 disabled:opacity-50"
+        />
+        <button
+          onClick={sendMessage}
+          disabled={isLoading || !input.trim()}
+          className="p-2 rounded-full bg-primary text-primary-foreground disabled:opacity-40 transition-opacity hover:opacity-80"
+        >
+          <IconSend className="size-4" />
+        </button>
       </div>
     </motion.div>
   );

--- a/components/common/chats/index.tsx
+++ b/components/common/chats/index.tsx
@@ -19,11 +19,6 @@ interface ChatMessage {
   content: string;
 }
 
-interface Params {
-  isOpen: boolean;
-  onClose?: () => void;
-}
-
 const GREETING: ChatMessage = {
   role: 'model',
   content:
@@ -73,15 +68,15 @@ const MarkdownContent = ({ content }: { content: string }) => (
   </ReactMarkdown>
 );
 
-const ChatBox = ({ isOpen, onClose }: Params) => {
+const ChatBoxContent = ({ onClose }: { onClose?: () => void }) => {
   const [messages, setMessages] = useState<ChatMessage[]>([GREETING]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (isOpen) setTimeout(() => inputRef.current?.focus(), 600);
-  }, [isOpen]);
+    setTimeout(() => inputRef.current?.focus(), 100);
+  }, []);
 
   const sendMessage = async () => {
     const text = input.trim();
@@ -93,7 +88,6 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
     setInput('');
     setIsLoading(true);
 
-    // Add empty assistant message to stream into
     setMessages(prev => [...prev, { role: 'model', content: '' }]);
 
     try {
@@ -140,26 +134,7 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
   };
 
   return (
-    <motion.div
-      className={cn(
-        'w-[400px] max-w-full h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] shadow-xl backdrop-filter backdrop-blur-lg flex flex-col overflow-hidden',
-        isOpen ? 'pointer-events-auto' : 'pointer-events-none'
-      )}
-      initial={{ opacity: 0 }}
-      animate={!!isOpen ? 'open' : 'closed'}
-      variants={{
-        open: () => ({
-          y: 0,
-          opacity: 100,
-          transition: { ease: 'easeInOut', duration: 0.5 },
-        }),
-        closed: () => ({
-          y: 80,
-          opacity: 0,
-          transition: { ease: 'easeOut', duration: 0.5 },
-        }),
-      }}
-    >
+    <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-primary/20">
         <div className="flex items-center gap-2">
@@ -215,8 +190,40 @@ const ChatBox = ({ isOpen, onClose }: Params) => {
           <IconSend className="size-4" />
         </button>
       </div>
+    </div>
+  );
+};
+
+interface ChatBoxParams {
+  isOpen: boolean;
+  onClose?: () => void;
+}
+
+const ChatBox = ({ isOpen, onClose }: ChatBoxParams) => {
+  return (
+    <motion.div
+      className={cn(
+        'w-[400px] max-w-full h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] shadow-xl backdrop-filter backdrop-blur-lg overflow-hidden',
+        isOpen ? 'pointer-events-auto' : 'pointer-events-none'
+      )}
+      initial={{ opacity: 0 }}
+      animate={isOpen ? 'open' : 'closed'}
+      variants={{
+        open: () => ({
+          y: 0,
+          opacity: 100,
+          transition: { ease: 'easeInOut', duration: 0.5 },
+        }),
+        closed: () => ({
+          y: 80,
+          opacity: 0,
+          transition: { ease: 'easeOut', duration: 0.5 },
+        }),
+      }}
+    >
+      {isOpen && <ChatBoxContent onClose={onClose} />}
     </motion.div>
   );
 };
 
-export { ChatBox };
+export { ChatBox, ChatBoxContent };

--- a/components/common/chats/index.tsx
+++ b/components/common/chats/index.tsx
@@ -2,10 +2,11 @@
 
 import { cn } from '@/lib/utils';
 import { motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { IconSend, IconX } from '@tabler/icons-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useChatContext } from '@/app/[locale]/_components/chat-context';
 import {
   Conversation,
   ConversationContent,
@@ -14,16 +15,7 @@ import {
 import { Message, MessageContent } from '@/components/ui/message';
 import { ShimmeringText } from '@/components/ui/shimmering-text';
 
-interface ChatMessage {
-  role: 'user' | 'model';
-  content: string;
-}
-
-const GREETING: ChatMessage = {
-  role: 'model',
-  content:
-    "Hi! I'm Hawoon's AI assistant. Ask me anything about his work, projects, or background.",
-};
+import type { ChatMessage } from '@/app/[locale]/_components/chat-context';
 
 const MarkdownContent = ({ content }: { content: string }) => (
   <ReactMarkdown
@@ -69,14 +61,19 @@ const MarkdownContent = ({ content }: { content: string }) => (
 );
 
 const ChatBoxContent = ({ onClose }: { onClose?: () => void }) => {
-  const [messages, setMessages] = useState<ChatMessage[]>([GREETING]);
-  const [input, setInput] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const {
+    messages,
+    setMessages,
+    input,
+    setInput,
+    isLoading,
+    setIsLoading,
+    inputRef,
+  } = useChatContext();
 
   useEffect(() => {
     setTimeout(() => inputRef.current?.focus(), 100);
-  }, []);
+  }, [inputRef]);
 
   const sendMessage = async () => {
     const text = input.trim();
@@ -203,7 +200,7 @@ const ChatBox = ({ isOpen, onClose }: ChatBoxParams) => {
   return (
     <motion.div
       className={cn(
-        'w-[400px] max-w-full h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] shadow-xl backdrop-filter backdrop-blur-lg overflow-hidden',
+        'w-[calc(100vw-3rem)] sm:w-[400px] max-w-full h-[60vh] sm:h-[480px] max-h-full bg-primary/20 end-0 rounded-[24px] shadow-xl backdrop-filter backdrop-blur-lg overflow-hidden',
         isOpen ? 'pointer-events-auto' : 'pointer-events-none'
       )}
       initial={{ opacity: 0 }}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+}

--- a/components/ui/conversation.tsx
+++ b/components/ui/conversation.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import type { ComponentProps } from "react"
+import { useCallback } from "react"
+import { ArrowDownIcon } from "lucide-react"
+import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+export type ConversationProps = ComponentProps<typeof StickToBottom>
+
+export const Conversation = ({ className, ...props }: ConversationProps) => (
+  <StickToBottom
+    className={cn("relative flex-1 overflow-y-auto", className)}
+    initial="smooth"
+    resize="smooth"
+    role="log"
+    {...props}
+  />
+)
+
+export type ConversationContentProps = ComponentProps<
+  typeof StickToBottom.Content
+>
+
+export const ConversationContent = ({
+  className,
+  ...props
+}: ConversationContentProps) => (
+  <StickToBottom.Content className={cn("p-4", className)} {...props} />
+)
+
+export type ConversationEmptyStateProps = Omit<
+  ComponentProps<"div">,
+  "title"
+> & {
+  title?: React.ReactNode
+  description?: React.ReactNode
+  icon?: React.ReactNode
+}
+
+export const ConversationEmptyState = ({
+  className,
+  title = "No messages yet",
+  description = "Start a conversation to see messages here",
+  icon,
+  children,
+  ...props
+}: ConversationEmptyStateProps) => (
+  <div
+    className={cn(
+      "flex size-full flex-col items-center justify-center gap-3 p-8 text-center",
+      className
+    )}
+    {...props}
+  >
+    {children ?? (
+      <>
+        {icon && <div className="text-muted-foreground">{icon}</div>}
+        <div className="space-y-1">
+          <h3 className="text-sm font-medium">{title}</h3>
+          {description && (
+            <p className="text-muted-foreground text-sm">{description}</p>
+          )}
+        </div>
+      </>
+    )}
+  </div>
+)
+
+export type ConversationScrollButtonProps = ComponentProps<typeof Button>
+
+export const ConversationScrollButton = ({
+  className,
+  ...props
+}: ConversationScrollButtonProps) => {
+  const { isAtBottom, scrollToBottom } = useStickToBottomContext()
+
+  const handleScrollToBottom = useCallback(() => {
+    scrollToBottom()
+  }, [scrollToBottom])
+
+  return (
+    !isAtBottom && (
+      <Button
+        className={cn(
+          "bg-background dark:bg-background absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full shadow-md",
+          className
+        )}
+        onClick={handleScrollToBottom}
+        size="icon"
+        type="button"
+        variant="outline"
+        {...props}
+      >
+        <ArrowDownIcon className="size-4" />
+      </Button>
+    )
+  )
+}

--- a/components/ui/message.tsx
+++ b/components/ui/message.tsx
@@ -1,0 +1,80 @@
+import type { ComponentProps, HTMLAttributes } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar"
+
+export type MessageProps = HTMLAttributes<HTMLDivElement> & {
+  from: "user" | "assistant"
+}
+
+export const Message = ({ className, from, ...props }: MessageProps) => (
+  <div
+    className={cn(
+      "group flex w-full items-end justify-end gap-2 py-4",
+      from === "user" ? "is-user" : "is-assistant flex-row-reverse justify-end",
+      className
+    )}
+    {...props}
+  />
+)
+
+const messageContentVariants = cva(
+  "is-user:dark flex flex-col gap-2 overflow-hidden rounded-lg text-sm",
+  {
+    variants: {
+      variant: {
+        contained: [
+          "max-w-[80%] px-4 py-3",
+          "group-[.is-user]:bg-primary group-[.is-user]:text-primary-foreground",
+          "group-[.is-assistant]:bg-secondary group-[.is-assistant]:text-foreground",
+        ],
+        flat: [
+          "group-[.is-user]:max-w-[80%] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+          "group-[.is-assistant]:text-foreground",
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: "contained",
+    },
+  }
+)
+
+export type MessageContentProps = HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof messageContentVariants>
+
+export const MessageContent = ({
+  children,
+  className,
+  variant,
+  ...props
+}: MessageContentProps) => (
+  <div
+    className={cn(messageContentVariants({ variant, className }))}
+    {...props}
+  >
+    {children}
+  </div>
+)
+
+export type MessageAvatarProps = ComponentProps<typeof Avatar> & {
+  src: string
+  name?: string
+}
+
+export const MessageAvatar = ({
+  src,
+  name,
+  className,
+  ...props
+}: MessageAvatarProps) => (
+  <Avatar className={cn("ring-border size-8 ring-1", className)} {...props}>
+    <AvatarImage alt="" className="mt-0 mb-0" src={src} />
+    <AvatarFallback>{name?.slice(0, 2) || "ME"}</AvatarFallback>
+  </Avatar>
+)

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/components/ui/shimmering-text.tsx
+++ b/components/ui/shimmering-text.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import React, { useMemo, useRef } from "react"
+import { motion, useInView, UseInViewOptions } from "motion/react"
+
+import { cn } from "@/lib/utils"
+
+interface ShimmeringTextProps {
+  /** Text to display with shimmer effect */
+  text: string
+  /** Animation duration in seconds */
+  duration?: number
+  /** Delay before starting animation */
+  delay?: number
+  /** Whether to repeat the animation */
+  repeat?: boolean
+  /** Pause duration between repeats in seconds */
+  repeatDelay?: number
+  /** Custom className */
+  className?: string
+  /** Whether to start animation when component enters viewport */
+  startOnView?: boolean
+  /** Whether to animate only once */
+  once?: boolean
+  /** Margin for in-view detection (rootMargin) */
+  inViewMargin?: UseInViewOptions["margin"]
+  /** Shimmer spread multiplier */
+  spread?: number
+  /** Base text color */
+  color?: string
+  /** Shimmer gradient color */
+  shimmerColor?: string
+}
+
+export function ShimmeringText({
+  text,
+  duration = 2,
+  delay = 0,
+  repeat = true,
+  repeatDelay = 0.5,
+  className,
+  startOnView = true,
+  once = false,
+  inViewMargin,
+  spread = 2,
+  color,
+  shimmerColor,
+}: ShimmeringTextProps) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const isInView = useInView(ref, { once, margin: inViewMargin })
+
+  // Calculate dynamic spread based on text length
+  const dynamicSpread = useMemo(() => {
+    return text.length * spread
+  }, [text, spread])
+
+  // Determine if we should start animation
+  const shouldAnimate = !startOnView || isInView
+
+  return (
+    <motion.span
+      ref={ref}
+      className={cn(
+        "relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",
+        "[--base-color:var(--muted-foreground)] [--shimmer-color:var(--foreground)]",
+        "[background-repeat:no-repeat,padding-box]",
+        "[--shimmer-bg:linear-gradient(90deg,transparent_calc(50%-var(--spread)),var(--shimmer-color),transparent_calc(50%+var(--spread)))]",
+        "dark:[--base-color:var(--muted-foreground)] dark:[--shimmer-color:var(--foreground)]",
+        className
+      )}
+      style={
+        {
+          "--spread": `${dynamicSpread}px`,
+          ...(color && { "--base-color": color }),
+          ...(shimmerColor && { "--shimmer-color": shimmerColor }),
+          backgroundImage: `var(--shimmer-bg), linear-gradient(var(--base-color), var(--base-color))`,
+        } as React.CSSProperties
+      }
+      initial={{
+        backgroundPosition: "100% center",
+        opacity: 0,
+      }}
+      animate={
+        shouldAnimate
+          ? {
+              backgroundPosition: "0% center",
+              opacity: 1,
+            }
+          : {}
+      }
+      transition={{
+        backgroundPosition: {
+          repeat: repeat ? Infinity : 0,
+          duration,
+          delay,
+          repeatDelay,
+          ease: "linear",
+        },
+        opacity: {
+          duration: 0.3,
+          delay,
+        },
+      }}
+    >
+      {text}
+    </motion.span>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noowah-next-v13",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,11 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "use-stick-to-bottom": "^1.1.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noowah-next-v13",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noowah-next-v13",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@splinetool/react-spline": "^4.1.0",
-    "@splinetool/runtime": "^1.10.76",
+    "@splinetool/runtime": "^1.12.70",
     "@tabler/icons-react": "^3.34.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,10 +32,10 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@splinetool/react-spline':
         specifier: ^4.1.0
-        version: 4.1.0(@splinetool/runtime@1.10.96)(next@16.0.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.1.0(@splinetool/runtime@1.12.70)(next@16.0.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@splinetool/runtime':
-        specifier: ^1.10.76
-        version: 1.10.96
+        specifier: ^1.12.70
+        version: 1.12.70
       '@tabler/icons-react':
         specifier: ^3.34.1
         version: 3.35.0(react@19.2.0)
@@ -90,6 +90,12 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.2)(react@19.2.0)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -1694,8 +1700,8 @@ packages:
       next:
         optional: true
 
-  '@splinetool/runtime@1.10.96':
-    resolution: {integrity: sha512-LGLhbi1x1R17QJRRf9NPM4FGWuWeUMXHO41cPFJ+wpyD8ybuk8+zcQ7kUy4liWuhYkZaZ+RaNXGXLjgkYE7MiA==}
+  '@splinetool/runtime@1.12.70':
+    resolution: {integrity: sha512-0h+48t+SG+I5idQLYibdnN8E4W3Wku9wNjRJgW+fLMj3B2YZTu7//ta7XswpFZb931vyXZa/B6jVFHlCy7Heaw==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1823,11 +1829,17 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1844,6 +1856,9 @@ packages:
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
@@ -1859,8 +1874,14 @@ packages:
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@22.19.0':
     resolution: {integrity: sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==}
@@ -1905,6 +1926,9 @@ packages:
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1967,6 +1991,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.46.3':
     resolution: {integrity: sha512-uk574k8IU0rOF/AjniX8qbLSGURJVUCeM5e4MIMKBFFi8weeiLrG1fyQejyLXQpRZbU/1BuQasleV/RfHC3hHg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2273,6 +2300,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2363,18 +2393,33 @@ packages:
   caniuse-lite@1.0.30001753:
     resolution: {integrity: sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
   character-entities-legacy@1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   character-entities@1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2414,6 +2459,9 @@ packages:
 
   comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -2518,6 +2566,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2569,6 +2620,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -2680,6 +2734,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-next@16.0.1:
     resolution: {integrity: sha512-wNuHw5gNOxwLUvpg0cu6IL0crrVC9hAwdS/7UwleNkwyaMiWIOAwf8yzXVqBBzL3c9A7jVRngJxjoSpPP1aEhg==}
@@ -2806,6 +2864,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2836,6 +2897,9 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -3086,6 +3150,12 @@ packages:
   hast-util-parse-selector@2.2.5:
     resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
 
@@ -3107,6 +3177,9 @@ packages:
 
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-deceiver@1.2.7:
     resolution: {integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==}
@@ -3168,6 +3241,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -3193,8 +3269,14 @@ packages:
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -3238,6 +3320,9 @@ packages:
   is-decimal@1.0.4:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3265,6 +3350,9 @@ packages:
 
   is-hexadecimal@1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -3294,6 +3382,10 @@ packages:
   is-plain-obj@3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
     engines: {node: '>=10'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -3519,6 +3611,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3541,9 +3636,57 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -3565,6 +3708,90 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3770,8 +3997,8 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
-  on-change@4.0.2:
-    resolution: {integrity: sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==}
+  on-change@4.0.0:
+    resolution: {integrity: sha512-PTu7C9Jsz4b+sNMDpH0eZFTr7uxdOtoDWRnhaVNK50bgrrnW5nvbWI0jm5DG9qOoTnIhBzE9xoKVFPD9xgtbdg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   on-exit-leak-free@2.1.2:
@@ -3819,6 +4046,9 @@ packages:
 
   parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -3913,6 +4143,9 @@ packages:
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -3986,6 +4219,12 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      react: '>=18'
 
   react-merge-refs@2.1.1:
     resolution: {integrity: sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==}
@@ -4065,6 +4304,18 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4276,6 +4527,9 @@ packages:
   space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
 
@@ -4341,6 +4595,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -4352,6 +4609,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -4457,6 +4720,12 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -4522,6 +4791,24 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -4582,6 +4869,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
@@ -4722,6 +5015,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -6433,9 +6729,9 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@splinetool/react-spline@4.1.0(@splinetool/runtime@1.10.96)(next@16.0.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@splinetool/react-spline@4.1.0(@splinetool/runtime@1.12.70)(next@16.0.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@splinetool/runtime': 1.10.96
+      '@splinetool/runtime': 1.12.70
       blurhash: 2.0.5
       lodash.debounce: 4.0.8
       react: 19.2.0
@@ -6445,9 +6741,9 @@ snapshots:
     optionalDependencies:
       next: 16.0.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@splinetool/runtime@1.10.96':
+  '@splinetool/runtime@1.12.70':
     dependencies:
-      on-change: 4.0.2
+      on-change: 4.0.0
       semver-compare: 1.0.0
 
   '@swc/helpers@0.5.15':
@@ -6574,6 +6870,10 @@ snapshots:
     dependencies:
       '@types/node': 22.19.0
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -6583,6 +6883,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
@@ -6611,6 +6915,10 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 2.0.11
+
   '@types/http-errors@2.0.5': {}
 
   '@types/http-proxy@1.17.17':
@@ -6623,7 +6931,13 @@ snapshots:
 
   '@types/lodash@4.17.20': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 2.0.11
+
   '@types/mime@1.3.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@22.19.0':
     dependencies:
@@ -6673,6 +6987,8 @@ snapshots:
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -6770,6 +7086,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.3
       eslint-visitor-keys: 4.2.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -7083,6 +7401,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -7182,16 +7502,26 @@ snapshots:
 
   caniuse-lite@1.0.30001753: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  character-entities-html4@2.1.0: {}
+
   character-entities-legacy@1.1.4: {}
+
+  character-entities-legacy@3.0.0: {}
 
   character-entities@1.2.4: {}
 
+  character-entities@2.0.2: {}
+
   character-reference-invalid@1.1.4: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -7236,6 +7566,8 @@ snapshots:
   colorette@2.0.20: {}
 
   comma-separated-tokens@1.0.8: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@14.0.3: {}
 
@@ -7328,6 +7660,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   default-browser-id@5.0.0: {}
@@ -7366,6 +7702,10 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   detect-node@2.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dns-packet@5.6.1:
     dependencies:
@@ -7566,6 +7906,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-next@16.0.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -7777,6 +8119,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -7828,6 +8172,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -8096,6 +8442,30 @@ snapshots:
 
   hast-util-parse-selector@2.2.5: {}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hastscript@6.0.0:
     dependencies:
       '@types/hast': 2.3.10
@@ -8122,6 +8492,8 @@ snapshots:
       obuf: 1.1.2
       readable-stream: 2.3.8
       wbuf: 1.7.3
+
+  html-url-attributes@3.0.1: {}
 
   http-deceiver@1.2.7: {}
 
@@ -8185,6 +8557,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -8235,10 +8609,17 @@ snapshots:
 
   is-alphabetical@1.0.4: {}
 
+  is-alphabetical@2.0.1: {}
+
   is-alphanumerical@1.0.4:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -8290,6 +8671,8 @@ snapshots:
 
   is-decimal@1.0.4: {}
 
+  is-decimal@2.0.1: {}
+
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
@@ -8314,6 +8697,8 @@ snapshots:
 
   is-hexadecimal@1.0.4: {}
 
+  is-hexadecimal@2.0.1: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -8332,6 +8717,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@3.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -8543,6 +8930,8 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -8566,7 +8955,162 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   media-typer@0.3.0: {}
 
@@ -8586,6 +9130,197 @@ snapshots:
   merge2@1.4.1: {}
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -8781,7 +9516,7 @@ snapshots:
 
   obuf@1.1.2: {}
 
-  on-change@4.0.2: {}
+  on-change@4.0.0: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -8843,6 +9578,16 @@ snapshots:
       is-alphanumerical: 1.0.4
       is-decimal: 1.0.4
       is-hexadecimal: 1.0.4
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parseurl@1.3.3: {}
 
@@ -8937,6 +9682,8 @@ snapshots:
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
+
+  property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -9077,6 +9824,24 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-markdown@10.1.0(@types/react@19.2.2)(react@19.2.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.2
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-merge-refs@2.1.1: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.2)(react@19.2.0):
@@ -9183,6 +9948,40 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -9451,6 +10250,8 @@ snapshots:
 
   space-separated-tokens@1.1.5: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spdy-transport@3.0.0:
     dependencies:
       debug: 4.4.3
@@ -9553,6 +10354,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -9560,6 +10366,14 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.0):
     dependencies:
@@ -9637,6 +10451,10 @@ snapshots:
       tslib: 2.8.1
 
   tree-kill@1.2.2: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -9723,6 +10541,39 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
@@ -9789,6 +10640,16 @@ snapshots:
   uuid@8.3.2: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   watchpack@2.4.4:
     dependencies:
@@ -9983,3 +10844,5 @@ snapshots:
   zod@4.1.12: {}
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      use-stick-to-bottom:
+        specifier: ^1.1.3
+        version: 1.1.3(react@19.2.0)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.11
@@ -4554,6 +4557,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-stick-to-bottom@1.1.3:
+    resolution: {integrity: sha512-GgRLdeGhxBxpcbrBbEIEoOKUQ9d46/eaSII+wyv1r9Du+NbCn1W/OE+VddefvRP4+5w/1kATN/6g2/BAC/yowQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -9765,6 +9773,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.2
+
+  use-stick-to-bottom@1.1.3(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:


### PR DESCRIPTION
## Summary
- Implement AI chat powered by OpenRouter with streaming markdown responses
- Add persistent Spline 3D bubble that morphs between fullscreen (home) and floating bubble (other pages), with deferred rendering on route transitions
- Use shadcn Popover for chat on non-home pages; animated overlay ChatBox on home
- Lift chat state into context so message history persists across route changes
- Fix mobile overflow for chat components and about page

## Test plan
- [ ] Verify chat opens and streams responses on home page
- [ ] Navigate to /about and back — chat history should persist
- [ ] Test Spline bubble animation on route change (home ↔ non-home)
- [ ] Check popover chat positioning and dismiss behavior on non-home pages
- [ ] Confirm no horizontal overflow on mobile for chat and about page